### PR TITLE
fix mac build

### DIFF
--- a/pixelselector/Justfile
+++ b/pixelselector/Justfile
@@ -59,13 +59,15 @@ create_bundle profile TargetDir:
         lipo {{TargetDir}}/{x86_64,aarch64}-apple-darwin/release/lib{{BinaryName}}.dylib -create -output {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}.dylib
         mv {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}.dylib {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}
     else
-        cp {{TargetDir}}/{{profile}}/{{BinaryName}}.rsrc {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources/{{PluginName}}.rsrc
+        cp {{TargetDir}}/{{profile}}/{{PluginName}}.rsrc {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources/{{PluginName}}.rsrc
         cp {{TargetDir}}/{{profile}}/lib{{BinaryName}}.dylib {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS/{{PluginName}}
     fi
 
     # codesign with the first development cert we can find using its hash
     if [ -z "$NO_SIGN" ]; then
-        codesign --options runtime --timestamp -strict  --sign $( security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}' ) {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+        # codesign --options runtime --timestamp -strict  --sign $( security find-identity -v -p codesigning | grep -m 1 "Apple Development" | awk -F ' ' '{print $2}' ) {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
+        # Apple Developer Programに入る必要があるが、開発中である為AdHoc署名で十分
+        codesign --options runtime --timestamp -strict  --sign - {{TargetDir}}/{{profile}}/{{PluginName}}.plugin
     fi
 
     # Install


### PR DESCRIPTION
# やったこと
- macosでのビルド時に吐き出される.rsrcのファイル名が期待したファイル名にならない為、`{{BinaryName}}`から`{{PluginName}}`に変更
- 署名をAdHoc署名に変更